### PR TITLE
remove backup and fog gem (runs one time)

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,15 @@ end
 
 > It is possible to load the settings in an *role* or an *data bag* or leave the settings in a recipe.
 
+## Remove backup gem
+
+some times a upgrade of the backup gem goes wrong in combination with fog
+or it just stops working.
+so when adding the recipe remove.rb to your run list
+it will remove the backup and fog gem
+and then it will remove the remove recipe from the run list again
+so this will run 1 time only
+
 License and Author
 -------------------
 

--- a/recipes/remove.rb
+++ b/recipes/remove.rb
@@ -1,0 +1,10 @@
+gem_package 'fog' do
+  action :remove
+end
+gem_package 'backup' do
+  action :remove
+end
+
+ruby_block 'remove_recipe_backup_remove' do
+  block { node.run_list.remove('recipe[backup::remove]') }
+end


### PR DESCRIPTION
i have had some problems with the latest backup gem
and needed to remove the fog and backup gem to rollback to old version

so what this does is
- removes fog gem
- removes backup gem
- removes recipe from the run-list


i don't know if this is of any use for someone but i just wanted to share it