### PR TITLE
Bump `version` to the latest version of the Backup gem

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,7 +11,7 @@ platforms:
   - name: ubuntu-14.04
     run_list:
     - recipe[apt]
-  - name: centos-6.4
+  - name: centos-6.6
 
 suites:
   - name: default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.2.4:
+
++ Improve testing material
++ Bump `version` to the latest version of the Backup gem
++ Include the dependencies it needs like zlib1g-dev and liblzma-dev (and centos varients)
+- Bump the centos version to 6.6
+
+
 ## v0.2.3:
 
 + check if `mailto` is defined and if it's not that's fine.
@@ -18,12 +26,12 @@
 
 ## v0.2.0:
 * Move from `crontab` resource to `cron_d`
-+ Fix a bug in `generate_config` that would prevent you from properly running 
++ Fix a bug in `generate_config` that would prevent you from properly running
 ```ruby
 backup_generate_config "bob" do
   action :remove
 end
-```  
+```
 + Improved the testing
 
 ## v0.1.0:
@@ -39,7 +47,7 @@ end
 * Update `providers/generate_model.rb` that used the parameter `remove` in error; it should be `delete`.
 * Create test scenario to exercise this code
 
-## v0.0.10: 
+## v0.0.10:
 
 * Remove references to require *Chef11*
 * Update reference to `split_into_chunks_of` as it is not set by default.
@@ -61,7 +69,7 @@ end
 ```ruby
 store_with({"engine" => "S3", "settings" => { "s3.access_key_id" => "S3_ACCESS_KEY", "s3.secret_access_key" => "S3_SECRET_ACCESS_KEY", "s3.bucket" => "BUCKET", "s3.path" => "DIR", "s3.keep" => 5, "s3.fog_options" => {  :host => 's3.DUMMY.DOMAIN.COM', :scheme => 'http', :port => 80 } } } )
   action :backup
-```  
+```
 
 - Removed blind rescue
 
@@ -79,7 +87,7 @@ store_with({"engine" => "S3", "settings" => { "s3.access_key_id" => "S3_ACCESS_K
 ## v0.0.5:
 
 * Improve README
-* Add Minitests 
+* Add Minitests
 * Use Inline Resources
 
 ## v.0.04:

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,13 +4,12 @@ maintainer_email "scott@likens.us"
 license          "Apache 2.0"
 description      "Installs/Configures backup"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.3"
+version          "0.2.4"
 
 %w{redhat centos fedora debian ubuntu}.each do |os|
   supports os
 end
 
 %w{build-essential cron}.each do |cb|
-  depends cb 
+  depends cb
 end
-

--- a/providers/install.rb
+++ b/providers/install.rb
@@ -6,18 +6,27 @@ use_inline_resources if defined?(use_inline_resources)
 
 action :install do
 
-libxslt1 = value_for_platform(
-                             ["centos", "redhat", "suse", "fedora" ] => { "default" => "libxslt-devel" },
-                             ["debian", "ubuntu" ] => { "default" => "libxslt1-dev" }
-                             )
- 
-libxml2 = value_for_platform(
-                             ["centos", "redhat", "suse", "fedora" ] => { "default" => "libxml2-devel" },
-                             ["debian", "ubuntu" ] => { "default" => "libxml2-dev" }
-                             )
-  package libxml2 
-  package libxslt1
+  lzmadev = value_for_platform(
+    ["centos","redhat","suse","fedora"] => { "default" => "xz-devel" },
+    ["debian","ubuntu"] => { "default" => "liblzma-dev" }
+  )
+  zlibdev = value_for_platform(
+    ["centos","redhat","suse","fedora"] => { "default" => "zlib-devel" },
+    ["debian","ubuntu"] => { "default" => "zlib1g-dev" }
+  )
+  libxslt1 = value_for_platform(
+    ["centos", "redhat", "suse", "fedora" ] => { "default" => "libxslt-devel" },
+    ["debian", "ubuntu" ] => { "default" => "libxslt1-dev" }
+  )
 
+  libxml2 = value_for_platform(
+    ["centos", "redhat", "suse", "fedora" ] => { "default" => "libxml2-devel" },
+    ["debian", "ubuntu" ] => { "default" => "libxml2-dev" }
+  )
+  package libxml2
+  package libxslt1
+  package zlibdev
+  package lzmadev
   gem_package "backup" do
     action :install
     version new_resource.version unless new_resource.version.empty?

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,7 +1,7 @@
 actions :install, :remove
 
 # Version of the backup gem to install
-attribute :version, :kind_of => String, :default => "4.1.5"
+attribute :version, :kind_of => String, :default => "4.1.10"
 
 def initialize(*args)
   super


### PR DESCRIPTION
  Include the dependencies it needs like zlib1g-dev and liblzma-dev (and centos varients)
Bump the centos version to 6.6

Refs #26

Signed-off-by: Scott M. Likens <scott@likens.us>