### PR TITLE
Update metadata name

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,4 @@
-name             "backup"
+name             "backup_lwrp"
 maintainer       "Scott M. Likens"
 maintainer_email "scott@likens.us"
 license          "Apache 2.0"


### PR DESCRIPTION
Supermarket name is `backup_lwrp`. Would it not make it more consistent to rename it in metadata as well?