### PR TITLE
Syncers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,25 @@ backup_generate_model "archive_attribute_test" do
 end
 ```
 
+### Syncers
+
+```ruby
+backup_generate_model "sync_my_docs" do
+  description  "Backup with RSync::Pull"
+  action :backup
+  backup_type "syncer"
+  gem_bin_dir "/opt/chef/embedded/bin"
+  options "add" => ["/home/username/documents", "/home/username/works"],
+          "exclude" => ["tmp"]
+  sync_with "syncer" => "RSync::Pull",
+            "settings" => { "syncer.path" => "/opt/backup/syncs",
+                            "syncer.mode" => :ssh,
+                            "syncer.additional_ssh_options" => "-i /home/username/.ssh/id_rsa",
+                            "syncer.host" => "192.168.0.42",
+                            "syncer.ssh_user" => "username" }
+end
+```
+
 > It is possible to load the settings in an *role* or an *data bag* or leave the settings in a recipe.
 
 License and Author

--- a/README.md
+++ b/README.md
@@ -164,7 +164,13 @@ Actions:
     <td>Hash</td>
     <td>Specify what  <a href="https://github.com/meskyanichi/backup/wiki/Storages">storage</a> engines you wish enable.</td>
     <td></td>
-    </tr>
+  </tr>
+  <tr>
+    <td><tt>sync_with</tt></td>
+    <td>Hash</td>
+    <td>Enable and configure <a href="http://backup.github.io/backup/v4/syncers/">Syncers</a> for this model.</td>
+    <td></td>
+  </tr>
   <tr>
     <td><tt>hour</tt></td>
     <td>String</td>

--- a/providers/generate_model.rb
+++ b/providers/generate_model.rb
@@ -26,7 +26,8 @@ action :backup do
                 :compress_with => new_resource.compress_with,
                 :notify_by => new_resource.notify_by,
                 :before_hook => new_resource.before_hook,
-                :after_hook => new_resource.after_hook
+                :after_hook => new_resource.after_hook,
+                :sync_with => new_resource.sync_with
               })
   end
   cron_d new_resource.name do

--- a/resources/generate_model.rb
+++ b/resources/generate_model.rb
@@ -44,6 +44,8 @@ attribute :encrypt_with, :kind_of => Hash
 attribute :compress_with, :kind_of => String, :default => "Gzip"
 # notify_by.  Ruby hash to specify how to notify your backups are completed
 attribute :notify_by, :kind_of => Hash
+# Enable and configure backup Syncers
+attribute :sync_with, :kind_of => Hash
 
 def initialize(*args)
   super

--- a/templates/default/generic_model.conf.erb
+++ b/templates/default/generic_model.conf.erb
@@ -76,4 +76,28 @@ Model.new(:<%= @name %>, '<%= @description %>') do
     <% end %>
   end
 <% end %>
+
+<% if @sync_with %>
+  sync_with <%= @sync_with["syncer"] %> do |syncer|
+  <% @sync_with["settings"].each_pair do |k,v| %>
+    <% if v.is_a? String %>
+    <%= k %> = "<%= v %>"
+    <% elsif v.is_a? Symbol %>
+    <%= k %> = :<%= v %>
+    <% else %>
+    <%= k %> = <%= v %>
+    <% end %>
+  <% end %>
+    syncer.directories do |directory|
+    <% @options["add"].each do |v| %>
+      directory.add '<%= v %>'
+    <% end %>
+    <% if @options["exclude"] %>
+    <% @options["exclude"].each do |v| %>
+      directory.exclude '<%= v %>'
+    <% end %>
+    <% end %>
+    end
+  end
+<% end %>
 end

--- a/test/cookbooks/backup_test/recipes/default.rb
+++ b/test/cookbooks/backup_test/recipes/default.rb
@@ -82,3 +82,21 @@ end
 execute "backup now archive_attribute_test" do
   command "#{node['languages']['ruby']['bin_dir']}/backup perform -t archive_attribute_test -c /opt/backup/config.rb"
 end
+
+# Need rsync package
+package 'rsync'
+backup_generate_model "sync_with_test" do
+  description "Test Syncers locally (with RSync::Local)"
+  backup_type "syncer"
+  action :backup
+  gem_bin_dir "/usr/local/bin"
+  options "add" => ["/opt/backup"],
+          "exclude" => ["log*"]
+  sync_with "syncer" => "RSync::Local",
+            "settings" => { "syncer.path" => "/tmp/sync",
+                            "syncer.mirror" => true }
+end
+
+execute "backup now sync_with_test" do
+  command "#{node['languages']['ruby']['bin_dir']}/backup perform -t sync_with_test -c /opt/backup/config.rb"
+end


### PR DESCRIPTION
Well, it's not perfect, but it does the job!

This change add `sync_with` attribute for `backup_generate_model` resource, add ten lines in the generic template (maybe this can be reduced) to generate syncers code, and a small example in readme.

I tested this with kitchen on `debian` platform:
```
platforms:
  - name: debian-8.1
    run_list:
    - recipe[apt]
```

I see that we can't disable compression setting (default is `Gzip`), passing nil to `compress_with` has no effect:
```
backup_generate_model "my_model" do
  ...
  compress_with nil
  ...
end
```
Will generate:
```
Model.new(:my_model, 'My model') do
  ...
  compress_with Gzip
  ...
end
```
It does not impede syncers to work, but it does not make sense to have the compression setting for Syncers..
