### PR TITLE
Default model compression to Gzip

### DIFF
--- a/resources/generate_model.rb
+++ b/resources/generate_model.rb
@@ -41,7 +41,7 @@ attribute :after_hook, :kind_of => String, :default => nil
 # encrypt_with.  Ruby Hash to specify how to encrypt your backups
 attribute :encrypt_with, :kind_of => Hash
 # Select the Compression Method (or disable it)
-attribute :compress_with
+attribute :compress_with, :kind_of => String, :default => "Gzip"
 # notify_by.  Ruby hash to specify how to notify your backups are completed
 attribute :notify_by, :kind_of => Hash
 # Enable and configure backup Syncers


### PR DESCRIPTION
  - README says it should be compressed by default
    but it is missing from resources/generate_model.rb