### PR TITLE
Update README with PostgreSQL custom format

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ backup_generate_model "pg" do
   database_type "PostgreSQL"
   split_into_chunks_of 2048
   store_with({"engine" => "S3", "settings" => { "s3.access_key_id" => "sample", "s3.secret_access_key" => "sample", "s3.region" => "us-east-1", "s3.bucket" => "sample", "s3.path" => "/", "s3.keep" => 10 } } )
-  options({"db.name" => "\"postgres\"", "db.username" => "\"postgres\"", "db.password" => "\"somepassword\"", "db.host" => "\"localhost\"" })
+  options({"db.name" => "\"postgres\"", "db.username" => "\"postgres\"", "db.password" => "\"somepassword\"", "db.host" => "\"localhost\"", "db.additional_options" => "[\" --format custom \"]"})
   mailto "sample@example.com"
   action :backup
 end


### PR DESCRIPTION
  - [custom format is the most flexible format][1] and it demos
    the additional_options which user might have to look up
  
  [1]: https://www.postgresql.org/docs/9.6/static/app-pgdump.html

I'm figuring it is easier to delete the format than work out how to add it ...